### PR TITLE
Add UBSan exception for valid underflow

### DIFF
--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#if defined(__clang__)
+# define __VMMU_UBSAN_NO_UNSIGNED_OVERFLOW__ __attribute__((no_sanitize("unsigned-integer-overflow")))
+#else
+# define __VMMU_UBSAN_NO_UNSIGNED_OVERFLOW__
+#endif

--- a/src/vmmu.hpp
+++ b/src/vmmu.hpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <variant>
 
+#include "compiler.hpp"
 #include "vmmu_utilities.hpp"
 
 namespace vmmu {
@@ -303,7 +304,7 @@ public:
   // above. It just caches its results in the TLB.
   //
   // TODO Write tests.
-  translate_result translate(linear_memory_op const &op, paging_state const &state, abstract_memory *memory)
+  translate_result __VMMU_UBSAN_NO_UNSIGNED_OVERFLOW__ translate(linear_memory_op const &op, paging_state const &state, abstract_memory *memory)
   {
     for (size_t i = 0; i < entries_.size(); i++) {
       auto const &entry = entries_[(pos_ + i) % entries_.size()];


### PR DESCRIPTION
There is a legitimate unsigned underflow of the `pos_` variable in the `tlb::translate` method.
This MR adds the necessary undefined behavior sanitizer attribute to prevent the sanitizer from reporting the underflow.